### PR TITLE
Fix typo in exercise 6 README

### DIFF
--- a/src/06/README.md
+++ b/src/06/README.md
@@ -10,6 +10,6 @@ We'll also use [forbidden transitions](https://xstate.js.org/docs/guides/transit
   - `running.normal`, which is the normal timer countdown behavior, and the initial state
   - `running.overtime`, which is the expired timer countdown behavior that can also be reset.
 - Move the eventless transition from `running` into `running.normal`, and transition to the sibling `overtime` instead of `expired`, since this is what we want our new behavior to be.
-- Since we now want to allow `RESET` to transition to `idle` in both `normal.overtime` and `paused`, move that transition to the parent, so that a `RESET` event would transition to `.idle`.
+- Since we now want to allow `RESET` to transition to `idle` in both `running.overtime` and `paused`, move that transition to the parent, so that a `RESET` event would transition to `.idle`.
 - However, we don't want a `RESET` event to do anything in `running.normal`, so forbid that transition.
 - We also don't want `TOGGLE` to do anything in `running.overtime`, so forbid that transition as well.


### PR DESCRIPTION
## Description
Hi, I noticed that there is a typo in exercise 6 README, `normal.overtime` should be `running.overtime` 
By the way, I have learned a lot from this course, thank you 👍