### PR TITLE
fix(package): force node major version to be 16

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   },
   "devDependencies": {
     "sass": "^1.42.1"
+  },
+  "engines": {
+    "node": "16"
   }
 }


### PR DESCRIPTION
There is an issue with node > 16 and the version of postcss

![Code_aGJlfN1U8v](https://user-images.githubusercontent.com/49202412/228663922-80473f71-84e6-4053-89bd-879e7e4232fc.png)

https://stackoverflow.com/questions/69693907/error-err-package-path-not-exported-package-subpath-lib-tokenize-is-not-d

I've enforced the node version to be 16.
The .npmrc is specially for npm in case somebody doesn't use yarn.
 
![Code_Txhk8ZnqAj](https://user-images.githubusercontent.com/49202412/228662918-cee4fc85-e623-478c-957b-ebb4a69ae7cd.png)
![Code_8SxclmBidN](https://user-images.githubusercontent.com/49202412/228663106-fb3ef0bf-3ed5-4d6a-b87c-e538b7ba7401.png)

Hope that can help, thanks for the course.
